### PR TITLE
fix: replace removed bitnami node base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-FROM public.ecr.aws/bitnami/node:20.18.1
-RUN apt-get install git
+# Official Node image from ECR Public — the bitnami catalog images were
+# removed upstream (versioned tags 404 since late 2025). Ships git already.
+FROM public.ecr.aws/docker/library/node:20.18.1
 ENV NODE_ENV=production
 RUN npm install -g typescript
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "usermap-server",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "lib/publisher.js",
   "author": "nouralharithi",
   "license": "MIT",


### PR DESCRIPTION
`public.ecr.aws/bitnami/node:20.18.1` was removed upstream (Bitnami pulled their versioned public catalog images), so every docker build fails — including the old `Build Image And Deploy` on master (see the 17:37 UTC failure today) and the new tag-publish for `v1.0.0`.

- Base image → `public.ecr.aws/docker/library/node:20.18.1` (official image mirrored on ECR Public; Debian-based, git included, no Docker Hub rate limits)
- Dropped the bare `apt-get install git` (git ships in the official image)
- Version bumped to 1.0.1 — `v1.0.0` never produced an image; the fixed build publishes as `v1.0.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)