### PR TITLE
ci: pin GitHub Actions to commit SHAs (FE-4376)

### DIFF
--- a/.github/workflows/on-sdk-update.yml
+++ b/.github/workflows/on-sdk-update.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
     - name: Setup node
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # v2
       with:
         node-version: '18.x'
         registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
## What

Pin all floating GitHub Actions refs in this repo to full commit SHAs (with `# version` comments), across workflow files and composite `action.yml` files. SHAs are the exact commits each tag/branch currently resolves to.

## Why

Part of the org-wide GitHub Actions hardening effort ([FE-4376](https://linear.app/driftprotocol/issue/FE-4376/improve-github-actions-security)). The `drift-labs` org now has `sha_pinning_required: true` and is moving off `Allow all actions` to a selected-actions allow-list. Floating refs (`@v1`, `@master`, …) must be pinned to full SHAs first so neither the pin-enforcement policy nor the allow-list flip breaks CI. Pinning to a SHA is the actual supply-chain defense (a mutable `@master`/tag can be moved by a compromised maintainer).

## Scope

Action ref pins only — no logic changes. Behavior preserved (e.g. `dtolnay/rust-toolchain@stable` pins to the stable-branch commit whose `action.yml` still defaults to the stable channel).