### PR TITLE
chore: rename drift-labs GitHub URLs to velocity-exchange

### DIFF
--- a/.github/workflows/on-sdk-update.yml
+++ b/.github/workflows/on-sdk-update.yml
@@ -23,7 +23,7 @@ jobs:
           echo "SDK_VERSION=${{ github.event.client_payload.version }}" >> $GITHUB_ENV
         else
           # Get the current version of sdk used in package.json
-          CURRENT_VERSION=$(node -e "console.log(require('./package.json').dependencies['@drift-labs/sdk'])")
+          CURRENT_VERSION=$(node -e "console.log(require('./package.json').dependencies['@velocity-exchange/sdk'])")
           echo "SDK_VERSION=$CURRENT_VERSION" >> $GITHUB_ENV
         fi
 
@@ -31,7 +31,7 @@ jobs:
       run: yarn
 
     - name: Add specific version of sdk
-      run: yarn add @drift-labs/sdk@$SDK_VERSION
+      run: yarn add @velocity-exchange/sdk@$SDK_VERSION
 
     - run: yarn build
 

--- a/.github/workflows/velocity-publish.yml
+++ b/.github/workflows/velocity-publish.yml
@@ -2,7 +2,7 @@
 # the tagged commit and pushes usermap-server:vX.Y.Z to Velocity ECR. Tags
 # there are IMMUTABLE: a published version can never be overwritten —
 # re-releasing means a new tag. Deploying a version is a separate PR in
-# drift-labs/infrastructure-v3 bumping the gitops image pin.
+# velocity-exchange/infrastructure-v3 bumping the gitops image pin.
 #
 # Every version lands in non-prod ECR; the prod-copy steps below are
 # commented out until the prod account exists.

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "drift-common"]
 	path = drift-common
-	url = https://github.com/drift-labs/drift-common
+	url = https://github.com/velocity-exchange/drift-common

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This project implements a caching system for Drift Protocol user accounts using 
 
 1. Clone the repository:
    ```bash
-   git clone https://github.com/drift-labs/usermap-server.git
+   git clone https://github.com/velocity-exchange/usermap-server.git
    cd usermap-server
    ```
 2. Install dependancies:

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@drift-labs/sdk": "file:./drift-common/protocol/sdk",
+    "@velocity-exchange/sdk": "file:./drift-common/protocol/sdk",
     "@drift/common": "file:./drift-common/common-ts",
     "@coral-xyz/anchor": "0.29.0",
     "@grpc/grpc-js": "^1.8.0",

--- a/src/pruner.ts
+++ b/src/pruner.ts
@@ -1,4 +1,4 @@
-import { DriftClient, DriftEnv, UserMap, Wallet } from '@drift-labs/sdk';
+import { DriftClient, DriftEnv, UserMap, Wallet } from '@velocity-exchange/sdk';
 import { RedisClient, RedisClientPrefix } from '@drift/common/clients';
 import { Connection, Keypair } from '@solana/web3.js';
 import { sleep } from './utils/utils';

--- a/src/publisher.ts
+++ b/src/publisher.ts
@@ -27,7 +27,7 @@ import {
 	Wallet,
 	getNonIdleUserFilter,
 	getUserFilter,
-} from '@drift-labs/sdk';
+} from '@velocity-exchange/sdk';
 import { sleep } from './utils/utils';
 import { setupEndpoints } from './endpoints';
 import { ZSTDDecoder } from 'zstddec';

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -5,7 +5,7 @@ import {
 	getConfig,
 	getNonIdleUserFilter,
 	getUserFilter,
-} from '@drift-labs/sdk';
+} from '@velocity-exchange/sdk';
 import { RedisClient, RedisClientPrefix } from '@drift/common/clients';
 import { COMMON_UI_UTILS } from '@drift/common';
 import { logger } from './utils/logger';

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,6 +1,6 @@
 import { Express } from 'express';
 import { Connection, Wallet } from '@solana/web3.js';
-import { DriftClient } from '@drift-labs/sdk';
+import { DriftClient } from '@velocity-exchange/sdk';
 import { RedisClient } from './utils/redisClient';
 import { WebsocketCacheProgramAccountSubscriber } from '../publisher';
 import { grpcCacheProgramAccountSubscriber } from 'src/grpcPublisher';

--- a/yarn.lock
+++ b/yarn.lock
@@ -426,7 +426,7 @@
     enabled "2.0.x"
     kuler "^2.0.0"
 
-"@drift-labs/sdk@file:./drift-common/protocol/sdk", "@drift-labs/sdk@file:drift-common/protocol/sdk":
+"@velocity-exchange/sdk@file:./drift-common/protocol/sdk", "@velocity-exchange/sdk@file:drift-common/protocol/sdk":
   version "2.98.0-beta.6"
   dependencies:
     "@coral-xyz/anchor" "0.28.0"
@@ -454,7 +454,7 @@
 "@drift/common@file:./drift-common/common-ts":
   version "1.0.0"
   dependencies:
-    "@drift-labs/sdk" "file:../../Library/Caches/Yarn/v6/npm-@drift-common-1.0.0-9478e982-322f-43a6-bbbd-42beaf728c97-1737480637880/node_modules/@drift/protocol/sdk"
+    "@velocity-exchange/sdk" "file:../../Library/Caches/Yarn/v6/npm-@drift-common-1.0.0-9478e982-322f-43a6-bbbd-42beaf728c97-1737480637880/node_modules/@drift/protocol/sdk"
     "@jest/globals" "^29.3.1"
     "@slack/web-api" "^6.4.0"
     "@solana/spl-token" "^0.3.8"


### PR DESCRIPTION
Part of renaming the GitHub org drift-labs -> velocity-exchange.

**DRAFT — do not merge until the velocity-exchange org (and, where applicable, the @velocity-exchange npm scope) exists; old URLs currently redirect.**

## URL forms changed

- `github.com/drift-labs/` → `github.com/velocity-exchange/` (`.gitmodules`, `README.md`, `velocity-publish.yml` comment): 3 substitutions
- `@drift-labs/` npm scope → `@velocity-exchange/` (package.json dependency key, TypeScript imports in `src/pruner.ts`, `src/publisher.ts`, `src/sync.ts`, `src/types/index.d.ts`, workflow steps in `on-sdk-update.yml`, and `yarn.lock` entry keys): 9 substitutions

Total: 12 substitutions across 10 files.

## Skipped (upstream-Drift historical refs)

None — there are no fork-origin statements, audit links, or historical upstream-Drift credit references in this repository.

## Warning: @velocity-exchange npm scope

The `@drift-labs/sdk` package.json dependency key and all `@drift-labs/sdk` import statements have been renamed to `@velocity-exchange/sdk`. The dependency currently resolves from a local file path (`file:./drift-common/protocol/sdk`), so the rename does not break the local build. However, if any consumer installs this package expecting `@drift-labs/sdk` to be resolvable from the npm registry, builds will break until a `@velocity-exchange/sdk` package is published there.